### PR TITLE
Use correct variable name

### DIFF
--- a/allfiles/AZ-300T02/Module_02/azuredeploy0401.json
+++ b/allfiles/AZ-300T02/Module_02/azuredeploy0401.json
@@ -114,7 +114,7 @@
             ],
             "properties": {
                 "osProfile": {
-                    "computerName": "[variables('vm1Name')]",
+                    "computerName": "[variables('vm2Name')]",
                     "adminUsername": "[parameters('adminUsername')]",
                     "adminPassword": "[parameters('adminPassword')]",
                     "windowsConfiguration": {


### PR DESCRIPTION
When running this lab, the computer name was wrong in the VM that was created from this template.  The template was referencing the incorrect variable.  This fixes the template.