### PR TITLE
Update AZ-300T01_Lab_Mod01_Exploring Monitoring Capabilities in Azure.md

### DIFF
--- a/Instructions/AZ-300T01_Lab_Mod01_Exploring Monitoring Capabilities in Azure.md
+++ b/Instructions/AZ-300T01_Lab_Mod01_Exploring Monitoring Capabilities in Azure.md
@@ -139,6 +139,8 @@ The main tasks for this exercise are as follows:
 
 1. In the **Condition** section, click **Add condition**, select the **Percentage CPU** metric, leave the dimension settings and condition type with their default values, set the condition to **Greater than**, set the time aggregation to **Average**, set the threshold to **60**, set the Aggregation granularity (period) to **1 minute**, set the frequency to **Every 1 minute** and click **done**.
 
+1. In the **Action* section, click **Add action**, select previously created action and click **done**.
+
 1. In the **Alert Details** section, set the alert rule name to **Percentage CPU of the VM scale set is greater than 60 percent**, its description to **Percentage CPU of the VM scale set is greater than 60 percent**, its severity to **Sev 3**, and set enable rule upon creation to **Yes**.
 
 1. Click **Create alert rule**.

--- a/Instructions/AZ-300T01_Lab_Mod01_Exploring Monitoring Capabilities in Azure.md
+++ b/Instructions/AZ-300T01_Lab_Mod01_Exploring Monitoring Capabilities in Azure.md
@@ -139,7 +139,7 @@ The main tasks for this exercise are as follows:
 
 1. In the **Condition** section, click **Add condition**, select the **Percentage CPU** metric, leave the dimension settings and condition type with their default values, set the condition to **Greater than**, set the time aggregation to **Average**, set the threshold to **60**, set the Aggregation granularity (period) to **1 minute**, set the frequency to **Every 1 minute** and click **done**.
 
-1. In the **Action* section, click **Add action**, select previously created action and click **done**.
+1. In the **Action** section, click **Add action**, select previously created action and click **done**.
 
 1. In the **Alert Details** section, set the alert rule name to **Percentage CPU of the VM scale set is greater than 60 percent**, its description to **Percentage CPU of the VM scale set is greater than 60 percent**, its severity to **Sev 3**, and set enable rule upon creation to **Yes**.
 


### PR DESCRIPTION
Basically wanting to add in information regarding the fact that the action created in an earlier step was not actually mentioned in terms of being utilized when creating the alert.

I was going to mention that the Azure CLI resource group removal didn't work but after checking again it does seem to be correct syntax wise. However I had more joy when only specifying 'az30', not sure why or if it was just a one off when trying what was mentioned.

Also noticed that Line 199 and 209 do not get rid off all resource groups that would get created if this lab was followed to the letter.