### PR TITLE
Updated to deprecate reference to lab VM login and suggest Cloud Shell

### DIFF
--- a/Instructions/AZ-300T01_Lab_Mod03_Implementing Custom Azure VM Images.md
+++ b/Instructions/AZ-300T01_Lab_Mod03_Implementing Custom Azure VM Images.md
@@ -20,9 +20,7 @@ After completing this lab, you will be able to:
 
 Estimated Time: 45 minutes
 
-User Name: **Student**
-
-Password: **Pa55w.rd**
+Interface: **Use Azure Cloud Shell in BASH mode**
 
 ## Exercise 1: Installing and configuring HashiCorp Packer
 


### PR DESCRIPTION
Azure labs are moving away from hosted labs VMs toward local execution and use of Azure Cloud Shell.