### PR TITLE
Update D1 to D2 size

### DIFF
--- a/Instructions/AZ-300T01_Lab_Mod01_Exploring Monitoring Capabilities in Azure.md
+++ b/Instructions/AZ-300T01_Lab_Mod01_Exploring Monitoring Capabilities in Azure.md
@@ -70,7 +70,7 @@ The main tasks for this exercise are as follows:
 
    - Location: the name of the Azure region that you referenced when running `Test-AzDnsAvailability` earlier in this task
 
-   - Vm Sku: **Standard_D1_v2**
+   - Vm Sku: **Standard_D2_v2**
 
    - Vmss Name: the custom label you identified when running `Test-AzDnsAvailability` earlier in this task
 

--- a/allfiles/AZ-300T01/Module_03/template03.json
+++ b/allfiles/AZ-300T01/Module_03/template03.json
@@ -21,7 +21,7 @@
     },
 
     "location": "$LOCATION",
-    "vm_size": "Standard_DS1_v2"
+    "vm_size": "Standard_DS2_v2"
   }],
   "provisioners": [{
     "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E sh '{{ .Path }}'",

--- a/allfiles/AZ-300T01/Module_05/azuredeploy05.json
+++ b/allfiles/AZ-300T01/Module_05/azuredeploy05.json
@@ -28,7 +28,7 @@
     },
     "vmSize": {
       "type": "string",
-      "defaultValue": "Standard_DS1_v2",
+      "defaultValue": "Standard_DS2_v2",
       "metadata": {
         "description": "This is the allowed list of VM sizes"
       }

--- a/allfiles/AZ-300T02/Module_03/azuredeploy04.parameters.json
+++ b/allfiles/AZ-300T02/Module_03/azuredeploy04.parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "vmSize": {
-            "value": "Standard_DS1_v2"
+            "value": "Standard_DS2_v2"
         },
         "adminUsername": {
             "value": "Student"

--- a/allfiles/AZ-300T03/Module_03/azuredeploy0801.json
+++ b/allfiles/AZ-300T03/Module_03/azuredeploy0801.json
@@ -58,7 +58,7 @@
     },
     "vmSize": {
       "type": "string",
-      "defaultValue": "Standard_DS1_v2",
+      "defaultValue": "Standard_DS2_v2",
       "metadata": {
         "description": "This is the VM size"
       }

--- a/allfiles/AZ-300T03/Module_03/azuredeploy0802.json
+++ b/allfiles/AZ-300T03/Module_03/azuredeploy0802.json
@@ -58,7 +58,7 @@
     },
     "vmSize": {
       "type": "string",
-      "defaultValue": "Standard_DS1_v2",
+      "defaultValue": "Standard_DS2_v2",
       "metadata": {
         "description": "This is the VM size"
       }


### PR DESCRIPTION
Hello, 
Many students are complaining about the Windows Server in hands-on about hanging for first time connection. Unfortunately, the DS1 and D1 series is not so powerful to produce student good experience with Windows Server 2016 Datacenter. It was a feedback from students and trainers to speed up the hands-on by allocating the higher series like DS2 and D2. The last task of the hands on is deleting all previously created VM so they should not run out of quotes or money for azure pass. Meanwhile those changes will increase satisfactions with hands-on task in class.

Thanks!