### PR TITLE
FIX: fix incorrect argument in Cloud Shell command

### DIFF
--- a/Instructions/AZ-300T01_Lab_Mod03_Implementing Custom Azure VM Images.md
+++ b/Instructions/AZ-300T01_Lab_Mod03_Implementing Custom Azure VM Images.md
@@ -184,7 +184,7 @@ The main tasks for this exercise are as follows:
 1. At the **Cloud Shell** command prompt, type in the following command and press **Enter** to list all resource groups you created in this lab:
 
    ```sh
-   az group list --query "[?starts_with(name,'az3000301')]".name --output tsv
+   az group list --query "[?starts_with(name,'az3000301')].name" --output tsv
    ```
 
 1. Verify that the output contains only the resource groups you created in this lab. These groups will be deleted in the next task.
@@ -194,7 +194,7 @@ The main tasks for this exercise are as follows:
 1. At the **Cloud Shell** command prompt, type in the following command and press **Enter** to delete the resource groups you created in this lab
 
    ```sh
-   az group list --query "[?starts_with(name,'az3000301')]".name --output tsv | xargs -L1 bash -c 'az group delete --name $0 --no-wait --yes'
+   az group list --query "[?starts_with(name,'az3000301')].name" --output tsv | xargs -L1 bash -c 'az group delete --name $0 --no-wait --yes'
    ```
 
 1. Close the **Cloud Shell** prompt at the bottom of the portal.

--- a/Instructions/AZ-300T02_Lab_Mod03_Configuring VNet peering and service chaining.md
+++ b/Instructions/AZ-300T02_Lab_Mod03_Configuring VNet peering and service chaining.md
@@ -252,7 +252,7 @@ The main tasks for this exercise are as follows:
 1. At the **Cloud Shell** command prompt, type in the following command and press **Enter** to list all resource groups you created in this lab:
 
    ```
-   az group list --query "[?starts_with(name,'az30004')]".name --output tsv
+   az group list --query "[?starts_with(name,'az30004')].name" --output tsv
    ```
 
 1. Verify that the output contains only the resource groups you created in this lab. These groups will be deleted in the next task.
@@ -262,7 +262,7 @@ The main tasks for this exercise are as follows:
 1. At the **Cloud Shell** command prompt, type in the following command and press **Enter** to delete the resource groups you created in this lab
 
    ```sh
-   az group list --query "[?starts_with(name,'az30004')]".name --output tsv | xargs -L1 bash -c 'az group delete --name $0 --no-wait --yes'
+   az group list --query "[?starts_with(name,'az30004')].name" --output tsv | xargs -L1 bash -c 'az group delete --name $0 --no-wait --yes'
    ```
 
 1. Close the **Cloud Shell** prompt at the bottom of the portal.

--- a/Instructions/AZ-300T03_Lab_Mod01_Implementing Azure Storage access controls.md
+++ b/Instructions/AZ-300T03_Lab_Mod01_Implementing Azure Storage access controls.md
@@ -221,7 +221,7 @@ The main tasks for this exercise are as follows:
 1. At the **Cloud Shell** command prompt, type in the following command and press **Enter** to list all resource groups you created in this lab:
 
    ```
-   az group list --query "[?starts_with(name,'az30002')]".name --output tsv
+   az group list --query "[?starts_with(name,'az30002')].name" --output tsv
    ```
 
 1. Verify that the output contains only the resource groups you created in this lab. These groups will be deleted in the next task.
@@ -231,7 +231,7 @@ The main tasks for this exercise are as follows:
 1. At the **Cloud Shell** command prompt, type in the following command and press **Enter** to delete the resource groups you created in this lab
 
    ```sh
-   az group list --query "[?starts_with(name,'az30002')]".name --output tsv | xargs -L1 bash -c 'az group delete --name $0 --no-wait --yes'
+   az group list --query "[?starts_with(name,'az30002')].name" --output tsv | xargs -L1 bash -c 'az group delete --name $0 --no-wait --yes'
    ```
 
 1. Close the **Cloud Shell** prompt at the bottom of the portal.

--- a/Instructions/AZ-300T03_Lab_Mod03_Implementing Azure Load Balancer Standard.md
+++ b/Instructions/AZ-300T03_Lab_Mod03_Implementing Azure Load Balancer Standard.md
@@ -396,7 +396,7 @@ The main tasks for this exercise are as follows:
 1. At the **Cloud Shell** command prompt, type in the following command and press **Enter** to list all resource groups you created in this lab:
 
    ```
-   az group list --query "[?starts_with(name,'az30008')]".name --output tsv
+   az group list --query "[?starts_with(name,'az30008')].name" --output tsv
    ```
 
 1. Verify that the output contains only the resource groups you created in this lab. These groups will be deleted in the next task.
@@ -406,7 +406,7 @@ The main tasks for this exercise are as follows:
 1. At the **Cloud Shell** command prompt, type in the following command and press **Enter** to delete the resource groups you created in this lab
 
    ```sh
-   az group list --query "[?starts_with(name,'az30008')]".name --output tsv | xargs -L1 bash -c 'az group delete --name $0 --no-wait --yes'
+   az group list --query "[?starts_with(name,'az30008')].name" --output tsv | xargs -L1 bash -c 'az group delete --name $0 --no-wait --yes'
    ```
 
 1. Close the **Cloud Shell** prompt at the bottom of the portal.

--- a/Instructions/AZ-300T03_Lab_Mod04_Implementing custom Role Based Access Control roles.md
+++ b/Instructions/AZ-300T03_Lab_Mod04_Implementing custom Role Based Access Control roles.md
@@ -229,7 +229,7 @@ The main tasks for this exercise are as follows:
 1. At the **Cloud Shell** command prompt, type in the following command and press **Enter** to list all resource groups you created in this lab:
 
    ```
-   az group list --query "[?starts_with(name,'az30009')]".name --output tsv
+   az group list --query "[?starts_with(name,'az30009')].name" --output tsv
    ```
 
 1. Verify that the output contains only the resource groups you created in this lab. These groups will be deleted in the next task.
@@ -239,7 +239,7 @@ The main tasks for this exercise are as follows:
 1. At the **Cloud Shell** command prompt, type in the following command and press **Enter** to delete the resource groups you created in this lab
 
    ```sh
-   az group list --query "[?starts_with(name,'az30009')]".name --output tsv | xargs -L1 bash -c 'az group delete --name $0 --no-wait --yes'
+   az group list --query "[?starts_with(name,'az30009')].name" --output tsv | xargs -L1 bash -c 'az group delete --name $0 --no-wait --yes'
    ```
 
 1. Close the **Cloud Shell** prompt at the bottom of the portal.

--- a/Instructions/AZ-300T04_Lab_Mod01_Implementing Azure Logic Apps.md
+++ b/Instructions/AZ-300T04_Lab_Mod01_Implementing Azure Logic Apps.md
@@ -276,7 +276,7 @@ The main tasks for this exercise are as follows:
 1. At the **Cloud Shell** command prompt, type in the following command and press **Enter** to list all resource groups you created in this lab:
 
    ```
-   az group list --query "[?starts_with(name,'az30007')]".name --output tsv
+   az group list --query "[?starts_with(name,'az30007')].name" --output tsv
    ```
 
 1. Verify that the output contains only the resource groups you created in this lab. These groups will be deleted in the next task.
@@ -286,7 +286,7 @@ The main tasks for this exercise are as follows:
 1. At the **Cloud Shell** command prompt, type in the following command and press **Enter** to delete the resource groups you created in this lab
 
    ```sh
-   az group list --query "[?starts_with(name,'az30007')]".name --output tsv | xargs -L1 bash -c 'az group delete --name $0 --no-wait --yes'
+   az group list --query "[?starts_with(name,'az30007')].name" --output tsv | xargs -L1 bash -c 'az group delete --name $0 --no-wait --yes'
    ```
 
 1. Close the **Cloud Shell** prompt at the bottom of the portal.

--- a/Instructions/AZ-300T06_Lab_Mod01_Configuring a Message-Based Integration Architecture.md
+++ b/Instructions/AZ-300T06_Lab_Mod01_Configuring a Message-Based Integration Architecture.md
@@ -306,7 +306,7 @@ The main tasks for this exercise are as follows:
 1. At the **Cloud Shell** command prompt, type in the following command and press **Enter** to list all resource groups you created in this lab:
 
    ```
-   az group list --query "[?starts_with(name,'az300T06')]".name --output tsv
+   az group list --query "[?starts_with(name,'az300T06')].name" --output tsv
    ```
 
 1. Verify that the output contains only the resource groups you created in this lab. These groups will be deleted in the next task.
@@ -316,7 +316,7 @@ The main tasks for this exercise are as follows:
 1. At the **Cloud Shell** command prompt, type in the following command and press **Enter** to delete the resource groups you created in this lab
 
    ```sh
-   az group list --query "[?starts_with(name,'az300T06')]".name --output tsv | xargs -L1 bash -c 'az group delete --name $0 --no-wait --yes'
+   az group list --query "[?starts_with(name,'az300T06')].name" --output tsv | xargs -L1 bash -c 'az group delete --name $0 --no-wait --yes'
    ```
 
 1. Close the **Cloud Shell** prompt at the bottom of the portal.


### PR DESCRIPTION
fix incorrect query command

PS Azure:\> az group list --query "[?starts_with(name,'az30009')]".name --output tsv
az group list: error: argument --query: expected one argument
usage: az group list [-h] [--verbose] [--debug]
                     [--output {json,jsonc,table,tsv,yaml,none}]
                     [--query JMESPATH] [--subscription _SUBSCRIPTION]
                     [--tag [TAG]]