### PR TITLE
Updating size of the vms to DS2_V2

### DIFF
--- a/allfiles/AZ-300T02/Module_03/azuredeploy04.parameters.json
+++ b/allfiles/AZ-300T02/Module_03/azuredeploy04.parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "vmSize": {
-            "value": "Standard_DS1_v2"
+            "value": "Standard_DS2_v2"
         },
         "adminUsername": {
             "value": "Student"


### PR DESCRIPTION
The specified size DS1_V2 is way to small, students have serious performance issues during the lab. 
Increasing the size to DS2_V2.