### PR TITLE
Change of syntax with 'az group deployment'

### DIFF
--- a/Instructions/AZ-300T01_Lab_Mod05_Implementing user-assigned managed identities for Azure resources.md
+++ b/Instructions/AZ-300T01_Lab_Mod05_Implementing user-assigned managed identities for Azure resources.md
@@ -65,7 +65,7 @@ The main tasks for this exercise are as follows:
 1. From the Cloud Shell pane, deploy an Azure VM hosting Windows Server 2016 Datacenter into the first virtual network by running:
 
    ```
-   az group deployment create --resource-group az3000501-LabRG --template-file azuredeploy05.json --parameters @azuredeploy05.parameters.json
+   az deployment group create --resource-group az3000501-LabRG --template-file azuredeploy05.json --parameters @azuredeploy05.parameters.json
    ```
 
    > **Note**: Wait for the deployment to complete. This might take about 5 minutes.

--- a/Instructions/AZ-300T02_Lab_Mod03_Configuring VNet peering and service chaining.md
+++ b/Instructions/AZ-300T02_Lab_Mod03_Configuring VNet peering and service chaining.md
@@ -70,7 +70,7 @@ The main tasks for this exercise are as follows:
 1. From the Cloud Shell pane, deploy the two Azure VMs hosting Windows Server 2016 Datacenter into the first virtual network by running:
 
    ```
-   az group deployment create --resource-group az3000401-LabRG --template-file azuredeploy0401.json --parameters @azuredeploy04.parameters.json --no-wait
+   az deployment group create --resource-group az3000401-LabRG --template-file azuredeploy0401.json --parameters @azuredeploy04.parameters.json --no-wait
    ```
 
     > **Note**: Do not wait for the deployment to complete but proceed to the next task.
@@ -83,7 +83,7 @@ The main tasks for this exercise are as follows:
 1. From the Cloud Shell pane, deploy an Azure VM hosting Windows Server 2016 Datacenter into the second virtual network by running:
 
    ```
-   az group deployment create --resource-group az3000402-LabRG --template-file azuredeploy0402.json --parameters @azuredeploy04.parameters.json --no-wait
+   az deployment group create --resource-group az3000402-LabRG --template-file azuredeploy0402.json --parameters @azuredeploy04.parameters.json --no-wait
    ```
 
     > **Note**: The second template uses the same parameter file. 

--- a/Instructions/AZ-300T03_Lab_Mod03_Implementing Azure Load Balancer Standard.md
+++ b/Instructions/AZ-300T03_Lab_Mod03_Implementing Azure Load Balancer Standard.md
@@ -69,7 +69,7 @@ The main tasks for this exercise are as follows:
 1. From the Cloud Shell pane, deploy a pair of Azure VMs hosting Windows Server 2016 Datacenter by running:
 
    ```
-   az group deployment create --resource-group az3000801-LabRG --template-file azuredeploy0801.json --parameters @azuredeploy0801.parameters.json
+   az deployment group create --resource-group az3000801-LabRG --template-file azuredeploy0801.json --parameters @azuredeploy0801.parameters.json
    ```
 
     > **Note**: Wait for the deployment before you proceed to the next task. This might take about 10 minutes.
@@ -305,7 +305,7 @@ The main tasks for this exercise are as follows:
 1. From the Cloud Shell pane, deploy a pair of Azure VMs hosting Windows Server 2016 Datacenter by running:
 
    ```
-   az group deployment create --resource-group az3000801-LabRG --template-file azuredeploy0802.json --parameters @azuredeploy0802.parameters.json
+   az deployment group create --resource-group az3000801-LabRG --template-file azuredeploy0802.json --parameters @azuredeploy0802.parameters.json
    ```
 
     > **Note**: Wait for the deployment before you proceed to the next task. This might take about 5 minutes.


### PR DESCRIPTION
Hello,
This command is implicitly deprecated because command group 'group deployment' is deprecated and will be removed in a future release. Use 'deployment group' instead.